### PR TITLE
Collab/Version-Control: Implemented Document Permissions & Started Backend Support For Document Groups

### DIFF
--- a/client/src/components/DocumentPage/Header/DocumentpageHeader.jsx
+++ b/client/src/components/DocumentPage/Header/DocumentpageHeader.jsx
@@ -1,4 +1,5 @@
 import { saveStatusEnum } from "../../../utils/constants";
+import "../../../pages/styles/DocumentPage.css";
 
 export default function DocumentHeader({
   documentTitle,
@@ -11,6 +12,7 @@ export default function DocumentHeader({
   user,
   loading,
   collaboratorProfiles,
+  userRole
 }) {
   return (
     <div className="document-header">
@@ -44,6 +46,7 @@ export default function DocumentHeader({
             onKeyDown={handleTitleChange}
             placeholder="Untitled document"
             id="title-input"
+            disabled={userRole === "VIEWER"}
           />
         </div>
       </div>

--- a/client/src/components/DocumentPage/Modals/ShareDocumentModal.jsx
+++ b/client/src/components/DocumentPage/Modals/ShareDocumentModal.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { shareDocument, getCollaborators, updateCollaboratorRole } from "../../../utils/dataFetcher";
+import {
+  shareDocument,
+  getCollaborators,
+  updateCollaboratorRole,
+} from "../../../utils/dataFetcher";
 import { useWS } from "../../../context/WebsocketContext";
 import { useUser } from "../../../hooks/useUser";
 import { dataActionEnum, documentRolesEnum } from "../../../utils/constants";
@@ -36,10 +40,10 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
           message: `${user.email} shared a document "${response.documentTitle}" with you.`,
           documentId,
         });
-        setEmail("")
+        setEmail("");
         // refetch collaborators
         const users = await getCollaborators(documentId);
-        setCollaborators(users)
+        setCollaborators(users);
       } else {
         const form = document.getElementById("user-search");
         form.style.borderColor = "red";
@@ -55,13 +59,13 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
     const newRole = e.target.value;
     try {
       await updateCollaboratorRole(documentId, collaboratorId, newRole);
-      setCollaborators(collaborators =>
-        collaborators.map(c =>
-          c.user.id === collaboratorId ? { ...c, role: newRole } : c
-        )
+      setCollaborators((collaborators) =>
+        collaborators.map((c) =>
+          c.user.id === collaboratorId ? { ...c, role: newRole } : c,
+        ),
       );
     } catch {
-      // TODO: Change to toast  
+      // TODO: Change to toast
       alert("Failed to update role");
     }
   };
@@ -112,7 +116,6 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
                       <option value={documentRolesEnum.ADMIN}>Admin</option>
                     </select>
                   </li>
-
                 );
               })}
             </ul>

--- a/client/src/components/DocumentPage/Modals/ShareDocumentModal.jsx
+++ b/client/src/components/DocumentPage/Modals/ShareDocumentModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
-import { shareDocument, getCollaborators } from "../../../utils/dataFetcher";
+import { shareDocument, getCollaborators, updateCollaboratorRole } from "../../../utils/dataFetcher";
 import { useWS } from "../../../context/WebsocketContext";
 import { useUser } from "../../../hooks/useUser";
-import { dataActionEnum } from "../../../utils/constants";
+import { dataActionEnum, documentRolesEnum } from "../../../utils/constants";
 import "./ShareDocumentModal.css";
 
 export default function ShareDocumentModal({ closeModal, documentId }) {
@@ -36,7 +36,10 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
           message: `${user.email} shared a document "${response.documentTitle}" with you.`,
           documentId,
         });
-        closeModal();
+        setEmail("")
+        // refetch collaborators
+        const users = await getCollaborators(documentId);
+        setCollaborators(users)
       } else {
         const form = document.getElementById("user-search");
         form.style.borderColor = "red";
@@ -45,6 +48,21 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
       const form = document.getElementById("user-search");
       form.style.borderColor = "red";
       form.placeholder = "Invalid email address";
+    }
+  };
+
+  const handleRoleChange = async (e, collaboratorId) => {
+    const newRole = e.target.value;
+    try {
+      await updateCollaboratorRole(documentId, collaboratorId, newRole);
+      setCollaborators(collaborators =>
+        collaborators.map(c =>
+          c.user.id === collaboratorId ? { ...c, role: newRole } : c
+        )
+      );
+    } catch {
+      // TODO: Change to toast  
+      alert("Failed to update role");
     }
   };
 
@@ -84,7 +102,17 @@ export default function ShareDocumentModal({ closeModal, documentId }) {
                     />
                     {data.user.email}{" "}
                     {data.user.email === globalUserEmail && "(You)"}
+                    <select
+                      value={data.role}
+                      disabled={data.user.email === globalUserEmail}
+                      onChange={(e) => handleRoleChange(e, data.user.id)}
+                    >
+                      <option value={documentRolesEnum.EDITOR}>Editor</option>
+                      <option value={documentRolesEnum.VIEWER}>Viewer</option>
+                      <option value={documentRolesEnum.ADMIN}>Admin</option>
+                    </select>
                   </li>
+
                 );
               })}
             </ul>

--- a/client/src/hooks/useQuill.js
+++ b/client/src/hooks/useQuill.js
@@ -1,14 +1,16 @@
 import { useEffect } from "react";
 import Quill from "quill";
 import QuillCursors from "quill-cursors";
+import { documentRolesEnum } from "../utils/constants";
 
 Quill.register("modules/cursors", QuillCursors);
 
-export default function useQuillEditor(editorRef, quillRef, onTextChange) {
+export default function useQuillEditor(editorRef, quillRef, onTextChange, userRole) {
   useEffect(() => {
     if (editorRef.current && !quillRef.current) {
       quillRef.current = new Quill(editorRef.current, {
         theme: "snow",
+        readOnly: userRole === documentRolesEnum.VIEWER,
         modules: {
           cursors: true,
           toolbar: [
@@ -22,5 +24,10 @@ export default function useQuillEditor(editorRef, quillRef, onTextChange) {
 
       quillRef.current.on("text-change", onTextChange);
     }
-  }, [editorRef, quillRef, onTextChange]);
+
+    // When userRole changes, update Quill's readOnly state
+    if (quillRef.current) {
+      quillRef.current.enable(userRole !== documentRolesEnum.VIEWER);
+    }
+  }, [editorRef, quillRef, onTextChange, userRole]);
 }

--- a/client/src/pages/DocumentPage.jsx
+++ b/client/src/pages/DocumentPage.jsx
@@ -15,9 +15,9 @@ import {
   getCollaboratorsProfiles,
   savePatch,
   updateDocumentTitle,
-  getColorForUser
 } from "../utils/dataFetcher";
 import { computeDeltaDiff } from "../hooks/deltaAlgo";
+import { getColorForUser } from "../utils/helpers";
 
 import "quill/dist/quill.snow.css";
 import "../pages/styles/DocumentPage.css";
@@ -101,7 +101,7 @@ export default function DocumentPage() {
     return unsubscribe;
   }, [user?.id, addListener]);
 
-  //  Render remote cursors 
+  //  Render remote cursors
   useEffect(() => {
     if (!quillRef.current || !quillRef.current.getModule) return;
     const cursors = quillRef.current.getModule("cursors");

--- a/client/src/pages/DocumentPage.jsx
+++ b/client/src/pages/DocumentPage.jsx
@@ -5,7 +5,7 @@ import { useWS } from "../context/WebsocketContext";
 import useQuillEditor from "../hooks/useQuill";
 import useDebouncedSave from "../hooks/useAutosave";
 import Delta from "../hooks/delta";
-import { saveStatusEnum, dataActionEnum } from "../utils/constants";
+import { saveStatusEnum, dataActionEnum, documentRolesEnum } from "../utils/constants";
 import ShareDocumentModal from "../components/DocumentPage/Modals/ShareDocumentModal";
 import VersionHistoryModal from "../components/DocumentPage/Modals/VersionHistoryModal";
 import DocumentHeader from "../components/DocumentPage/Header/DocumentpageHeader";
@@ -15,6 +15,7 @@ import {
   getCollaboratorsProfiles,
   savePatch,
   updateDocumentTitle,
+  getUserRole
 } from "../utils/dataFetcher";
 import { computeDeltaDiff } from "../hooks/deltaAlgo";
 import { getColorForUser } from "../utils/helpers";
@@ -36,6 +37,7 @@ export default function DocumentPage() {
   const [saveStatus, setSaveStatus] = useState(saveStatusEnum.SAVED);
   const [collaboratorProfiles, setCollaboratorProfiles] = useState([]);
   const [remoteCursors, setRemoteCursors] = useState({});
+  const [userRole, setUserRole] = useState(null);
   const lastSavedDeltaRef = useRef(new Delta());
   const lastSelectionRef = useRef(null);
 
@@ -153,7 +155,25 @@ export default function DocumentPage() {
     lastSavedDeltaRef.current = newDelta;
   };
 
-  useQuillEditor(editorRef, quillRef, handleTextChange);
+
+  // Fetch and set user role
+  useEffect(() => {
+  const fetchAndSetRole = async () => {
+    if (!documentId || !user?.id) return;
+    try {
+      const data = await getUserRole(documentId);
+      setUserRole(data.role);
+    } catch (err) {
+      // TODO: Add Toast Error handlng
+      console.error("Failed to load collaborators", err);
+    }
+  }
+  fetchAndSetRole();
+}, [documentId, user?.id]);
+
+
+
+  useQuillEditor(editorRef, quillRef, handleTextChange, userRole);
 
   // Broadcast cursor position
   useEffect(() => {
@@ -202,7 +222,7 @@ export default function DocumentPage() {
       quill.off("selection-change", handleSelectionChange);
       quill.off("text-change", handleTextChange);
     };
-  }, [sendMessage, user?.id, documentId, quillRef]);
+  }, [sendMessage, user?.id, documentId, quillRef, user.email]);
 
   // Load document content
   useEffect(() => {
@@ -244,6 +264,22 @@ export default function DocumentPage() {
     }
   };
 
+  const handleShareModal = () => {
+    if (userRole === documentRolesEnum.VIEWER || userRole === documentRolesEnum.EDITOR){
+      return;
+    }
+
+    setShowShareModal(true);
+  };
+
+  const handlerVersionHistoryModal = () => {
+    if (userRole === documentRolesEnum.VIEWER){
+      return;
+    }
+    setShowVersionHistoryModal(true);
+  };
+
+
   return (
     <div className="document-page">
       <DocumentHeader
@@ -252,13 +288,14 @@ export default function DocumentPage() {
         handleTitleChange={handleTitleChange}
         saveStatus={saveStatus}
         navigate={navigate}
-        openShareModal={() => setShowShareModal(true)}
-        openVersionModal={() => setShowVersionHistoryModal(true)}
+        openShareModal={() => handleShareModal()}
+        openVersionModal={() => handlerVersionHistoryModal()}
         user={user}
         loading={loading}
         collaboratorProfiles={
           <ActiveCollaborators profiles={collaboratorProfiles} />
         }
+        userRole={userRole}
       />
       <div className="document-content">
         <div className="editor-container">

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -14,3 +14,8 @@ export const saveStatusEnum = {
 };
 
 
+export const documentRolesEnum = {
+  EDITOR: "EDITOR",
+  VIEWER: "VIEWER",
+  ADMIN: "ADMIN",
+};

--- a/client/src/utils/dataFetcher.js
+++ b/client/src/utils/dataFetcher.js
@@ -59,10 +59,8 @@ const createDocument = async (title) => {
       body: JSON.stringify(data),
     });
     if (!response.ok) throw new Error("Failed to create document");
-    console.log("Document created successfully");
     return await response.json();
   } catch (error) {
-    console.log("error");
     console.error("Cannot create document", error.message);
     return null;
   }
@@ -77,7 +75,6 @@ const getDocumentContent = async (documentId) => {
     });
     if (!response.ok) throw new Error("Failed to fetch document content");
     const content = await response.json();
-    console.log("Document content fetched successfully");
     return content;
   } catch (error) {
     console.error("Cannot get document content", error.message);
@@ -269,11 +266,10 @@ const getVersionContent = async (documentId, versionNumber) => {
   }
 };
 
-
 const updateCollaboratorRole = async (documentId, userId, newRole) => {
   const URL = `${baseURL}/documents/${documentId}/collaborators/${userId}`;
 
-  try{
+  try {
     const response = await fetch(URL, {
       method: httpMethod.PATCH,
       credentials: "include",
@@ -287,7 +283,24 @@ const updateCollaboratorRole = async (documentId, userId, newRole) => {
     console.error("Cannot update collaborator role", error.message);
     throw error;
   }
-}
+};
+
+const getUserRole = async (documentId) => {
+  const URL = `${baseURL}/documents/${documentId}/userRole`;
+
+  try {
+    const response = await fetch(URL, {
+      credentials: "include",
+    });
+    if (!response.ok) throw new Error("Failed to fetch user role");
+
+    const userRole = await response.json();
+    return userRole;
+  } catch (error) {
+    console.error("Cannot get user role", error.message);
+    throw error;
+  }
+};
 
 export {
   getUserData,
@@ -304,4 +317,5 @@ export {
   updateDocumentTitle,
   getVersionContent,
   updateCollaboratorRole,
+  getUserRole
 };

--- a/client/src/utils/dataFetcher.js
+++ b/client/src/utils/dataFetcher.js
@@ -269,13 +269,24 @@ const getVersionContent = async (documentId, versionNumber) => {
   }
 };
 
-const getColorForUser = (userId) => {
-  const colors = ["#fa3", "#39f", "#2e2", "#f39", "#c83"];
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+
+const updateCollaboratorRole = async (documentId, userId, newRole) => {
+  const URL = `${baseURL}/documents/${documentId}/collaborators/${userId}`;
+
+  try{
+    const response = await fetch(URL, {
+      method: httpMethod.PATCH,
+      credentials: "include",
+      headers: httpHeaders,
+      body: JSON.stringify({ role: newRole }),
+    });
+
+    if (!response.ok) throw new Error("Failed to update collaborator role");
+    return response.json();
+  } catch (error) {
+    console.error("Cannot update collaborator role", error.message);
+    throw error;
   }
-  return colors[Math.abs(hash) % colors.length];
 }
 
 export {
@@ -292,5 +303,5 @@ export {
   revertToVersion,
   updateDocumentTitle,
   getVersionContent,
-  getColorForUser
+  updateCollaboratorRole,
 };

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -1,0 +1,8 @@
+export const getColorForUser = (userId) => {
+  const colors = ["#fa3", "#39f", "#2e2", "#f39", "#c83"];
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}

--- a/server/controllers/groupHelper.js
+++ b/server/controllers/groupHelper.js
@@ -1,0 +1,38 @@
+import { PrismaClient } from "../generated/prisma/client.js";
+const prisma = new PrismaClient();
+
+export async function isDocumentAdminOrOwner(userId, documentId) {
+  // Check if user is document owner
+  const doc = await prisma.document.findUnique({
+    where: { id: documentId },
+    select: { ownerId: true }
+  });
+  if (!doc) return false;
+  if (doc.ownerId === userId) return true;
+
+  // Find all groups this user is a member of for this document
+  const userGroups = await prisma.userGroup.findMany({
+    where: {
+      documentId,
+      members: {
+        some: { id: userId }
+      }
+    },
+    select: { id: true },
+  });
+  const groupIds = userGroups.map((g) => g.id);
+
+  // Check both direct user permissions and group permissions
+  const adminPermission = await prisma.documentPermission.findFirst({
+    where: {
+      documentId,
+      role: "ADMIN",
+      OR: [
+        { userId, groupId: null },
+        ...(groupIds.length > 0 ? [{ groupId: { in: groupIds }, userId: null }] : [])
+      ],
+    },
+  });
+
+  return !!adminPermission;
+}

--- a/server/controllers/groups.js
+++ b/server/controllers/groups.js
@@ -1,0 +1,224 @@
+import { PrismaClient } from "../generated/prisma/client.js";
+import { isDocumentAdminOrOwner } from "./groupHelper.js";
+const prisma = new PrismaClient();
+
+// Create a group
+export async function createGroup(req, res) {
+  const { name, defaultRole, documentId } = req.body;
+  const ownerId = req.user.id;
+
+  if (!name || !defaultRole || !documentId) {
+    return res.status(400).json({ message: "Missing required fields" });
+  }
+
+  try {
+    const group = await prisma.userGroup.create({
+      data: {
+        name,
+        defaultRole,
+        document: { connect: { id: documentId } },
+        owner: { connect: { id: ownerId } },
+        members: { connect: { id: ownerId } },
+      },
+      include: { members: true },
+    });
+
+    res.status(201).json({ group });
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ message: "Failed to create group" });
+  }
+}
+
+
+
+// Add member to group
+export async function addGroupMember(req, res) {
+  const { groupId } = req.params;
+  const { email } = req.body;
+
+  // Check if group exists
+  const group = await prisma.userGroup.findUnique({
+    where: { id: groupId },
+    include: { document: true }
+  });
+  if (!group) return res.status(404).json({ message: "Group not found" });
+
+  // Check permissions
+  if (group.ownerId !== req.user.id)
+    return res.status(403).json({ message: "Only owner can add" });
+
+  // Find user by email
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return res.status(404).json({ message: "User not found" });
+
+  try {
+    // Add user to group
+    await prisma.userGroup.update({
+      where: { id: groupId },
+      data: { members: { connect: { id: user.id } } },
+    });
+
+    // Create group permission for the document if it doesn't exist
+    const existingGroupPermission = await prisma.documentPermission.findFirst({
+      where: {
+        documentId: group.documentId,
+        groupId: groupId,
+        userId: null,
+      },
+    });
+
+    if (!existingGroupPermission) {
+      await prisma.documentPermission.create({
+        data: {
+          documentId: group.documentId,
+          groupId: groupId,
+          userId: null,
+          role: group.defaultRole,
+          grantedBy: req.user.id,
+        },
+      });
+    }
+
+    res.status(200).json({ message: "Group member added successfully" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to add group member" });
+  }
+}
+
+// Remove member from group
+export async function removeGroupMember(req, res) {
+  const { groupId, userId } = req.params;
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId } });
+  if (!group) return res.status(404).json({ message: "Group not found" });
+  if (group.ownerId !== req.user.id)
+    return res.status(403).json({ message: "Only owner can remove" });
+  try {
+    await prisma.userGroup.update({
+      where: { id: groupId },
+      data: { members: { disconnect: { id: userId } } },
+    });
+    res.status(200).json({ message: "Group member removed successfully" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to remove group member" });
+  }
+}
+
+// Delete group
+export async function deleteGroup(req, res) {
+  const { groupId } = req.params;
+  const group = await prisma.userGroup.findUnique({ where: { id: groupId } });
+  if (!group) return res.status(404).json({ message: "Group not found" });
+
+  if (group.ownerId !== req.user.id)
+    return res.status(403).json({ message: "Only owner can delete" });
+  try {
+    await prisma.userGroup.delete({ where: { id: groupId } });
+    res.sendStatus(204);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to delete group" });
+  }
+}
+
+// Share doc with group
+export async function addGroupPermission(req, res) {
+  const { docId } = req.params;
+  const { groupId, role } = req.body;
+  const userId = req.user.id;
+
+  // Doc admin/owner check
+  if (!(await isDocumentAdminOrOwner(userId, docId))) {
+    return res
+      .status(403)
+      .json({
+        message: "Only doc admin/owner can edit group permissions for this doc",
+      });
+  }
+
+  try {
+    // Check if permission already exists for this group and document
+    const existingPermission = await prisma.documentPermission.findFirst({
+      where: {
+        documentId: docId,
+        groupId: groupId,
+        userId: null,
+      },
+    });
+
+    let perm;
+    if (existingPermission) {
+      // Update existing permission
+      perm = await prisma.documentPermission.update({
+        where: { id: existingPermission.id },
+        data: { role },
+      });
+    } else {
+      // Create new permission
+      perm = await prisma.documentPermission.create({
+        data: {
+          documentId: docId,
+          groupId,
+          userId: null,
+          role,
+          grantedBy: userId,
+        },
+      });
+    }
+
+    res.status(201).json({ perm });
+  } catch (error) {
+    console.error("Error adding group permission:", error);
+    res.status(500).json({ message: "Failed to add group permission" });
+  }
+}
+
+// List groups user belongs to for a specific document
+export async function listGroups(req, res) {
+  const userId = req.user.id;
+  const { documentId } = req.query;
+
+  if (!documentId) {
+    return res.status(400).json({ message: "documentId is required" });
+  }
+
+  try {
+    const groups = await prisma.userGroup.findMany({
+      where: {
+        documentId: documentId,
+        members: { some: { id: userId } }
+      },
+      include: {
+        members: { select: { id: true, email: true, image: true } },
+      },
+    });
+    res.status(200).json(groups);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to list groups" });
+  }
+}
+
+// List all groups user belongs to (across all documents)
+export async function listAllGroups(req, res) {
+  const userId = req.user.id;
+
+  try {
+    const groups = await prisma.userGroup.findMany({
+      where: {
+        members: { some: { id: userId } }
+      },
+      include: {
+        members: { select: { id: true, email: true, image: true } },
+        document: { select: { id: true, title: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    res.status(200).json(groups);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to list all groups" });
+  }
+}

--- a/server/controllers/server.mjs
+++ b/server/controllers/server.mjs
@@ -22,6 +22,16 @@ import {
   getUserRole,
 } from "./documents.js";
 
+import {
+  createGroup,
+  addGroupMember,
+  removeGroupMember,
+  deleteGroup,
+  addGroupPermission,
+  listGroups,
+  listAllGroups,
+} from "./groups.js";
+
 const app = express();
 app.use(express.json());
 app.use(
@@ -79,25 +89,35 @@ app.use((req, res, next) => {
   next();
 });
 
+
+// API routes
 app.get("/documents", getDocuments);
 app.get("/documents/:id/content", getDocumentContent);
 app.get("/documents/:id/collaborators", getDocumentCollaborators);
-app.get("/documents/:id/userRole", getUserRole)
+app.get("/documents/:id/userRole", getUserRole);
 app.get("/users/:id", getUserData);
 app.get("/documents/:id/versions", getVersions);
 app.get("/documents/:id/versions/:versionNumber", getVersionContent);
+app.get("/groups", listGroups);
+app.get("/groups/all", listAllGroups);
+
 app.post("/documents", createDocument);
 app.post("/documents/:id/patches", savePatch);
 app.post("/documents/:id/share", shareDocument);
 app.post("/users/profiles", getUserProfiles);
 app.post("/documents/:id/revert", revertVersion);
+app.post("/groups", createGroup);
+app.post("/groups/:groupId/members", addGroupMember);
+app.post("/documents/:docId/permissions/group", addGroupPermission);
+
 app.put("/documents/:id/snapshot", updateSnapshot);
+
 app.patch("/documents/:id", updateDocumentTitle);
-app.patch(
-  "/documents/:documentId/collaborators/:userId",
-  updateCollaboratorRole,
-);
+app.patch("/documents/:documentId/collaborators/:userId", updateCollaboratorRole);
+
+app.delete("/groups/:groupId", deleteGroup);
 app.delete("/documents/:id", deleteDocument);
+app.delete("/groups/:groupId/members/:userId", removeGroupMember);
 
 app.get("/me", (req, res) => {
   res.json(req.user);

--- a/server/controllers/server.mjs
+++ b/server/controllers/server.mjs
@@ -18,6 +18,7 @@ import {
   revertVersion,
   updateDocumentTitle,
   getVersionContent,
+  updateCollaboratorRole,
 } from "./documents.js";
 
 const app = express();
@@ -90,6 +91,7 @@ app.post("/users/profiles", getUserProfiles);
 app.post("/documents/:id/revert", revertVersion);
 app.put("/documents/:id/snapshot", updateSnapshot);
 app.patch("/documents/:id", updateDocumentTitle);
+app.patch("/documents/:documentId/collaborators/:userId", updateCollaboratorRole)
 app.delete("/documents/:id", deleteDocument);
 
 app.get("/me", (req, res) => {

--- a/server/controllers/server.mjs
+++ b/server/controllers/server.mjs
@@ -19,6 +19,7 @@ import {
   updateDocumentTitle,
   getVersionContent,
   updateCollaboratorRole,
+  getUserRole,
 } from "./documents.js";
 
 const app = express();
@@ -81,6 +82,7 @@ app.use((req, res, next) => {
 app.get("/documents", getDocuments);
 app.get("/documents/:id/content", getDocumentContent);
 app.get("/documents/:id/collaborators", getDocumentCollaborators);
+app.get("/documents/:id/userRole", getUserRole)
 app.get("/users/:id", getUserData);
 app.get("/documents/:id/versions", getVersions);
 app.get("/documents/:id/versions/:versionNumber", getVersionContent);
@@ -91,7 +93,10 @@ app.post("/users/profiles", getUserProfiles);
 app.post("/documents/:id/revert", revertVersion);
 app.put("/documents/:id/snapshot", updateSnapshot);
 app.patch("/documents/:id", updateDocumentTitle);
-app.patch("/documents/:documentId/collaborators/:userId", updateCollaboratorRole)
+app.patch(
+  "/documents/:documentId/collaborators/:userId",
+  updateCollaboratorRole,
+);
 app.delete("/documents/:id", deleteDocument);
 
 app.get("/me", (req, res) => {

--- a/server/prisma/migrations/20250722174906_document_permissions/migration.sql
+++ b/server/prisma/migrations/20250722174906_document_permissions/migration.sql
@@ -1,0 +1,92 @@
+-- CreateEnum
+CREATE TYPE "DocumentRole" AS ENUM ('VIEWER', 'EDITOR', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "DocumentPermission" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "userId" TEXT,
+    "groupId" TEXT,
+    "role" "DocumentRole" NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "grantedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DocumentPermission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ShareLink" (
+    "id" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "urlToken" TEXT NOT NULL,
+    "role" "DocumentRole" NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT NOT NULL,
+
+    CONSTRAINT "ShareLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserGroup" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroupMembership" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GroupMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_GroupMembers" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_GroupMembers_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DocumentPermission_documentId_userId_groupId_key" ON "DocumentPermission"("documentId", "userId", "groupId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ShareLink_urlToken_key" ON "ShareLink"("urlToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GroupMembership_userId_groupId_key" ON "GroupMembership"("userId", "groupId");
+
+-- CreateIndex
+CREATE INDEX "_GroupMembers_B_index" ON "_GroupMembers"("B");
+
+-- AddForeignKey
+ALTER TABLE "DocumentPermission" ADD CONSTRAINT "DocumentPermission_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentPermission" ADD CONSTRAINT "DocumentPermission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocumentPermission" ADD CONSTRAINT "DocumentPermission_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "UserGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShareLink" ADD CONSTRAINT "ShareLink_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMembership" ADD CONSTRAINT "GroupMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupMembership" ADD CONSTRAINT "GroupMembership_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "UserGroup"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_GroupMembers" ADD CONSTRAINT "_GroupMembers_A_fkey" FOREIGN KEY ("A") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_GroupMembers" ADD CONSTRAINT "_GroupMembers_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -21,109 +21,111 @@ enum DocumentRole {
 }
 
 model User {
-  id                String               @id @default(cuid())
-  googleId          String               @unique
-  email             String               @unique
-  image             String
-  accessToken       String
-  refreshToken      String
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @default(now())
+  id           String   @id @default(cuid())
+  googleId     String   @unique
+  email        String   @unique
+  image        String
+  accessToken  String
+  refreshToken String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @default(now())
 
-  documents         Document[]
-  versions          Version[]
-  collaborators     Collaborator[]
-  groups            UserGroup[]
+  documents          Document[]
+  versions           Version[]
+  collaborators      Collaborator[]
+  groups             UserGroup[]          @relation("GroupMembers")
+  DocumentPermission DocumentPermission[]
+  GroupMembership    GroupMembership[]
 }
 
 model Document {
-  id                String               @id @default(cuid())
-  title             String
-  content           Json
-  createdAt         DateTime             @default(now())
-  updatedAt         DateTime             @default(now())
-  ownerId           String
-  owner             User                 @relation(fields: [ownerId], references: [id])
+  id        String   @id @default(cuid())
+  title     String
+  content   Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+  ownerId   String
+  owner     User     @relation(fields: [ownerId], references: [id])
 
-  collaborators     Collaborator[]
-  versions          Version[]
-  permissions       DocumentPermission[]
-  shareLinks        ShareLink[]
+  collaborators Collaborator[]
+  versions      Version[]
+  permissions   DocumentPermission[]
+  shareLinks    ShareLink[]
 }
 
 model Version {
-  id                String               @id @default(cuid())
-  documentId        String
-  userId            String
-  versionNumber     Int
-  diff              Json
-  isSnapshot        Boolean              @default(false)
-  createdAt         DateTime             @default(now())
+  id            String   @id @default(cuid())
+  documentId    String
+  userId        String
+  versionNumber Int
+  diff          Json
+  isSnapshot    Boolean  @default(false)
+  createdAt     DateTime @default(now())
 
-  document          Document             @relation(fields: [documentId], references: [id])
-  user              User                 @relation(fields: [userId], references: [id])
+  document Document @relation(fields: [documentId], references: [id])
+  user     User     @relation(fields: [userId], references: [id])
 
   @@unique([documentId, versionNumber])
 }
 
-
 model Collaborator {
-  id                String               @id @default(cuid())
-  userId            String
-  documentId        String
-  joinedAt          DateTime             @default(now())
+  id         String   @id @default(cuid())
+  userId     String
+  documentId String
+  joinedAt   DateTime @default(now())
 
-  user              User                 @relation(fields: [userId], references: [id])
-  document          Document             @relation(fields: [documentId], references: [id])
+  user     User     @relation(fields: [userId], references: [id])
+  document Document @relation(fields: [documentId], references: [id])
 
   @@unique([userId, documentId])
 }
 
-
 model DocumentPermission {
-  id                String               @id @default(cuid())
-  documentId        String
-  userId            String?
-  groupId           String?
-  role              DocumentRole
-  expiresAt         DateTime?
-  grantedBy         String
-  createdAt         DateTime             @default(now())
+  id         String       @id @default(cuid())
+  documentId String
+  userId     String?
+  groupId    String?
+  role       DocumentRole
+  expiresAt  DateTime?
+  grantedBy  String
+  createdAt  DateTime     @default(now())
 
-  document          Document             @relation(fields: [documentId], references: [id])
-  user              User?                @relation(fields: [userId], references: [id])
-  group             UserGroup?           @relation(fields: [groupId], references: [id])
+  document Document   @relation(fields: [documentId], references: [id])
+  user     User?      @relation(fields: [userId], references: [id])
+  group    UserGroup? @relation(fields: [groupId], references: [id])
 
   @@unique([documentId, userId, groupId])
 }
 
 model ShareLink {
-  id          String                     @id @default(cuid())
-  documentId  String
-  urlToken    String                     @unique
-  role        DocumentRole
-  expiresAt   DateTime?
-  createdAt   DateTime                   @default(now())
-  createdBy   String
+  id         String       @id @default(cuid())
+  documentId String
+  urlToken   String       @unique
+  role       DocumentRole
+  expiresAt  DateTime?
+  createdAt  DateTime     @default(now())
+  createdBy  String
 
-  document    Document                   @relation(fields: [documentId], references: [id])
+  document Document @relation(fields: [documentId], references: [id])
 }
 
 model UserGroup {
-  id          String                     @id @default(cuid())
-  name        String
-  members     User[]                     @relation("GroupMembers")
-  createdAt   DateTime                   @default(now())
+  id                 String               @id @default(cuid())
+  name               String
+  members            User[]               @relation("GroupMembers")
+  createdAt          DateTime             @default(now())
+  DocumentPermission DocumentPermission[]
+  GroupMembership    GroupMembership[]
 }
 
 model GroupMembership {
-  id        String                       @id @default(cuid())
-  userId    String
-  groupId   String
-  joinedAt  DateTime                     @default(now())
+  id       String   @id @default(cuid())
+  userId   String
+  groupId  String
+  joinedAt DateTime @default(now())
 
-  user      User                         @relation(fields: [userId], references: [id])
-  group     UserGroup                    @relation(fields: [groupId], references: [id])
+  user  User      @relation(fields: [userId], references: [id])
+  group UserGroup @relation(fields: [groupId], references: [id])
 
   @@unique([userId, groupId])
 }


### PR DESCRIPTION
### Description

- **Document Permissions:** Users can assign document permissions using the following roles:
      - **Viewer:** Can only view the document.
      -  **Editor:** Can edit the document, revert versions, change doc title but cannot manage members.
      - **Admin:** Has full privileges except document deletion.

- **Backend for Document Groups:** Initial backend routes for document groups have been implemented as part of supporting document permissions. Full functionality will be detailed in a future PR.



### Notes
Apologies in advanced for this long PR. Yesterday commits stacked on top 